### PR TITLE
fix autocomplete for launch-ide

### DIFF
--- a/extension/completion/create-docker-id-file.sh
+++ b/extension/completion/create-docker-id-file.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-_UseGetOpt() {
+_UseGetOpt_create_docker_id_file() {
     local CUR &&
         COMPREPLY=() &&
         CUR=${COMP_WORDS[COMP_CWORD]} &&
@@ -11,4 +11,4 @@ _UseGetOpt() {
         esac
   return 0
 } &&
-    complete -F _UseGetOpt -o filenames /usr/local/bin/create-docker-id-file create-docker-id-file --
+    complete -F _UseGetOpt_create_docker_id_file -o filenames /usr/local/bin/create-docker-id-file create-docker-id-file --

--- a/extension/completion/launch-ide-inner.sh
+++ b/extension/completion/launch-ide-inner.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-_UseGetOpt() {
+_UseGetOpt_launch_ide_inner() {
     local CUR &&
         COMPREPLY=() &&
         CUR=${COMP_WORDS[COMP_CWORD]} &&
@@ -11,4 +11,4 @@ _UseGetOpt() {
         esac
   return 0
 } &&
-    complete -F _UseGetOpt -o filenames /usr/local/bin/launch-ide-inner launch-ide-inner --
+    complete -F _UseGetOpt_launch_ide_inner -o filenames /usr/local/bin/launch-ide-inner launch-ide-inner --

--- a/extension/completion/launch-ide.sh
+++ b/extension/completion/launch-ide.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-_UseGetOpt() {
+_UseGetOpt_launch_ide() {
     local CUR &&
         COMPREPLY=() &&
         CUR=${COMP_WORDS[COMP_CWORD]} &&
@@ -11,4 +11,4 @@ _UseGetOpt() {
         esac
   return 0
 } &&
-    complete -F _UseGetOpt -o filenames /usr/local/bin/launch-ide launch-ide --
+    complete -F _UseGetOpt_launch_ide -o filenames /usr/local/bin/launch-ide launch-ide --

--- a/extension/completion/launch-secret-editor.sh
+++ b/extension/completion/launch-secret-editor.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-_UseGetOpt() {
+_UseGetOpt_launch_secret_editor() {
     local CUR &&
         COMPREPLY=() &&
         CUR=${COMP_WORDS[COMP_CWORD]} &&
@@ -11,4 +11,4 @@ _UseGetOpt() {
         esac
   return 0
 } &&
-    complete -F _UseGetOpt -o filenames /usr/local/bin/launch-secret-editor launch-secret-editor --
+    complete -F _UseGetOpt_launch_secret_editor -o filenames /usr/local/bin/launch-secret-editor launch-secret-editor --


### PR DESCRIPTION
this is a kludge fix

the problem is that I created a _UseGetOpt for each autocompletion.
in my mind they are all local functions and the completion will use the right one.
in bash's mind, they are all global and rewriting the last one.
all completions will use the last defined _UseGetOpt function.

A better solution would be to figure out how to make _UseGetOpt a local.
The current kludge solution is to rename each function.